### PR TITLE
feat: 메인 페이지 레이아웃

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,20 +1,15 @@
-import PageLayout from '@/components/PageLayout';
 import Header from '@/components/Header';
-import Input from '@/components/Input';
-import Test from '@/ui/Test';
+import PageLayout from '@/components/PageLayout';
+import MainContainer from '@/ui/mainPage/MainContainer';
 
-export default async function Page() {
+export default function Page() {
   return (
     <>
       <PageLayout.TopFixed>
         <Header />
       </PageLayout.TopFixed>
-      <PageLayout.Contents className="flex flex-col">
-        <h1 className="my-4 text-3xl">Main Page</h1>
-
-        <div className="flex flex-1 flex-col items-center">
-          <Input readOnly />
-        </div>
+      <PageLayout.Contents>
+        <MainContainer />
       </PageLayout.Contents>
     </>
   );

--- a/components/Input/index.tsx
+++ b/components/Input/index.tsx
@@ -68,8 +68,8 @@ const Input = ({
         ref={ref}
         className={cn(
           'box-border border-b-2 border-secondary-900 bg-transparent text-[20px] outline-none focus:border-b-primary-500',
-          'placeholder:text-secondary-600',
-          'w-full py-[8px]',
+          'placeholder:text-grey-500',
+          'w-full py-[15px]',
           'disabled:opacity-[.32]',
           { 'pl-[42px] pr-[15px]': isDefaultType || isActiveType },
           { 'pr-[76px]': isValueType },

--- a/ui/mainPage/GithubProfile.tsx
+++ b/ui/mainPage/GithubProfile.tsx
@@ -1,0 +1,5 @@
+const GithubProfile = () => {
+  return <section className="absolute bottom-0 mb-[42px]">기여해주신 분들</section>;
+};
+
+export default GithubProfile;

--- a/ui/mainPage/MainContainer.tsx
+++ b/ui/mainPage/MainContainer.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import cn from 'classnames';
+import PageLayout from '@/components/PageLayout';
+import Header from '@/components/Header';
+import Subtitle from '@/components/Typography/Subtitle';
+import Input from '@/components/Input';
+import Headline from '@/components/Typography/Headline';
+import Button from '@/components/Button';
+import SearchSuggestion from '@/ui/mainPage/SearchSuggestion';
+import GithubProfile from '@/ui/mainPage/GithubProfile';
+
+const MainContainer = () => {
+  return (
+    <>
+      <section className={cn('mt-16')}>
+        <Headline type="h1">Find Lecture</Headline>
+        <Subtitle type="sub1">궁금한 강의 정보를 검색해 보세요.</Subtitle>
+        <Input readOnly placeholder="강의명,강의자로 검색" />
+      </section>
+      <SearchSuggestion />
+      <Button size="lg" className={cn('mt-8 w-full')}>
+        전체 강의 보기
+      </Button>
+      <GithubProfile />
+    </>
+  );
+};
+
+export default MainContainer;

--- a/ui/mainPage/SearchSuggestion.tsx
+++ b/ui/mainPage/SearchSuggestion.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import Button from '@/components/Button';
+import Headline from '@/components/Typography/Headline';
+
+const SearchSuggestion = () => {
+  return (
+    <section className={'mt-7'}>
+      <Headline type="h5">이런 검색어는 어떠세요?</Headline>
+      <div className="mt-2 flex flex-wrap items-center gap-x-1 gap-y-2">
+        <Button color="white" size="sm">
+          드림코드엘리
+        </Button>
+        <Button color="white" size="sm">
+          드림코드엘리
+        </Button>
+        <Button color="white" size="sm">
+          드림코드엘리
+        </Button>
+        <Button color="white" size="sm">
+          드림코드엘리
+        </Button>
+        <Button color="white" size="sm">
+          드림코드엘리
+        </Button>
+        <Button color="white" size="sm">
+          드림코드엘리
+        </Button>
+        <Button color="white" size="sm">
+          드림코드엘리
+        </Button>
+        <Button color="white" size="sm">
+          드림코드엘리
+        </Button>
+        <Button color="white" size="sm">
+          드림코드엘리
+        </Button>
+      </div>
+    </section>
+  );
+};
+
+export default SearchSuggestion;


### PR DESCRIPTION
너무 길어질 거 같아 메인 페이지 레이아웃 먼저 리뷰 요청드립니다~
ui 디렉토리 내부 컴포넌트 관리 현재 방향으로 가면 될지 의견 주시면 좋을 거 같습니당
- mainPage에서 사용할 컴포넌트들을 하나의 디렉토리에 모아두었는데 
이게 아니라 각각 컴포넌트 단위 (예 GithubProfile) 로 디렉토리를 나누는게 더 나을 거 같기도 하고 그래서 아직도 고민 중입니다.

### 참고
`feature/main-page` 브랜치는 쪼개서 리뷰 요청드리고 한번에 모아서 develop 브랜치에 넣기 위한 브랜치입니다.