### PR TITLE
feat: ScrollToTop 컴포넌트 throttle 사용해서 최적화, 커스텀 훅으로 분리

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -14,6 +14,7 @@ const config: StorybookConfig = {
   webpackFinal: async (config) => {
     (config.resolve as any).alias = {
       ['@/components']: path.resolve(__dirname, '../components'),
+      ['@/hooks']: path.resolve(__dirname, '../hooks'),
     };
     return config;
   },

--- a/components/Icons/ArrowUp.tsx
+++ b/components/Icons/ArrowUp.tsx
@@ -1,0 +1,17 @@
+import IconBase, { type IconProps } from './IconBase';
+
+const ArrowUp = (props: Omit<IconProps, 'children'>) => {
+  return (
+    <IconBase viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        d="M6.85714 8.46814L12 3M12 3L17.1429 8.41543M12 3V17.1429M3 21H21"
+        stroke="black"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </IconBase>
+  );
+};
+
+export default ArrowUp;

--- a/components/Icons/index.ts
+++ b/components/Icons/index.ts
@@ -1,8 +1,9 @@
 import ArrowLeft from './ArrowLeft';
+import ArrowUp from './ArrowUp';
 import CloseCircle from './CloseCircle';
 import Heart from './Heart';
 import Profile from './Profile';
 import Search from './Search';
 import Add from './Add';
 
-export { ArrowLeft, CloseCircle, Heart, Profile, Search, Add };
+export { ArrowLeft, ArrowUp, CloseCircle, Heart, Profile, Search, Add };

--- a/components/ScrollToTop/ScrollToTop.constants.ts
+++ b/components/ScrollToTop/ScrollToTop.constants.ts
@@ -1,0 +1,2 @@
+export const THRESHOLD = 300;
+export const WAIT = 500;

--- a/components/ScrollToTop/index.tsx
+++ b/components/ScrollToTop/index.tsx
@@ -1,0 +1,27 @@
+import cn from 'classnames';
+import { THRESHOLD, WAIT } from './ScrollToTop.constants';
+import { ArrowUp } from '@/components/Icons';
+import { useThrottleScroll } from '@/hooks/useThrottleScroll';
+
+export default function ScrollToTop() {
+  const options = {
+    threshold: THRESHOLD,
+    wait: WAIT,
+  };
+  const { isVisible, handleScrollToTop } = useThrottleScroll(options);
+
+  return (
+    <>
+      {isVisible ? (
+        <button
+          className={cn(
+            'fixed bottom-5 right-5 flex h-[52px] w-[52px] flex-shrink-0 items-center justify-center gap-1 rounded-full bg-white p-4 shadow-md transition-transform duration-200 ease-in-out hover:-translate-y-1 hover:scale-105',
+          )}
+          onClick={handleScrollToTop}
+        >
+          <ArrowUp color="black" size="md" />
+        </button>
+      ) : null}
+    </>
+  );
+}

--- a/hooks/useThrottleScroll.ts
+++ b/hooks/useThrottleScroll.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect } from 'react';
+import throttle from 'lodash/throttle';
+
+interface Options {
+  threshold: number;
+  wait: number;
+}
+
+export const useThrottleScroll = (options: Options) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = throttle(() => {
+      setIsVisible(window.scrollY > options.threshold);
+    }, options.wait);
+
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [options]);
+
+  const handleScrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'auto',
+    });
+  };
+
+  return { isVisible, handleScrollToTop };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "eslint": "8.41.0",
         "eslint-config-next": "13.4.4",
         "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
         "next": "13.4.4",
         "postcss": "8.4.24",
         "react": "18.2.0",
@@ -11102,8 +11103,8 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -22589,7 +22590,8 @@
     },
     "lodash": {
       "version": "4.17.21",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "eslint": "8.41.0",
     "eslint-config-next": "13.4.4",
     "js-yaml": "^4.1.0",
+    "lodash": "^4.17.21",
     "next": "13.4.4",
     "postcss": "8.4.24",
     "react": "18.2.0",

--- a/stories/ScrollToTop.stories.tsx
+++ b/stories/ScrollToTop.stories.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import type { StoryObj } from '@storybook/react';
+import ScrollToTopComponent from '@/components/ScrollToTop';
+
+export default {
+  title: 'Components/ScrollToTop',
+  component: ScrollToTopComponent,
+};
+
+type Story = StoryObj<typeof ScrollToTopComponent>;
+
+export const ScrollToTop: Story = {
+  render: () => (
+    <>
+      <div className="h-screen bg-gray-200">page 1</div>
+      <div className="h-screen bg-blue-200">page 2</div>
+      <div className="h-screen bg-pink-200">page 3</div>
+      <ScrollToTopComponent />
+    </>
+  ),
+};


### PR DESCRIPTION
close #35 

> handleScroll 함수는 스크롤 이벤트가 발생할 때마다 호출되기 때문에, 스크롤이 빈번하게 발생하는 경우에는 성능 문제가 발생할 수도 있을 것 같아요..!
또한, ScrollToTop 버튼이 1px 단위로 스크롤 값을 계산해서 300px 이상일때만 "꼭" 보여줘야만 하는 UI는 아니라고 생각해서, 최적화 측면에서 조금 수정되면 어떨까요 ?.?
throttle이나 debounce를 사용해서 스크롤 이벤트의 호출 빈도를 제어해보면 좋을 것 같습니다.
Intersection Observer API 를 활용해서, 스크롤이 돼서 제일 위의 요소가 보이지 않아지는 경우에만 ScrollToTop을 노출 시키는 것도 방법일 것 같습니다.

Intersection Observer API 보다 throttle이 적합하다고 판단해서 lodash를 사용해서 적용해보았습니다~!