### PR TITLE
feat: lectures, creators API 정보 추가

### DIFF
--- a/server/controllers/lectures.ts
+++ b/server/controllers/lectures.ts
@@ -14,7 +14,7 @@ export const getLecturesFromGithub = async (): Promise<Lectures> => {
   const { items: creators } = await getCreatorsFromGithub();
   const lectures: Lecutre[] = [];
 
-  for (const { lectures: githubLectures } of creators) {
+  for (const { lectures: githubLectures, name: creator, category } of creators) {
     for (const githubLecture of githubLectures) {
       const { name: lectureName, path: lecturePath } = githubLecture;
       const lectureContentsPath = `${lecturePath}/CONTENTS.md`;
@@ -28,6 +28,8 @@ export const getLecturesFromGithub = async (): Promise<Lectures> => {
       lectures.push({
         name: removeHyphensAndConvertToSpaces(lectureName),
         markdown,
+        creator,
+        category,
         frontmatter: {
           platforms,
           hashtags,
@@ -60,6 +62,7 @@ export const searchLecturesFromAlgolia = async (search: string): Promise<Lecture
 export const saveLecturesToAlgolia = async () => {
   try {
     const { items: lectures } = await getLecturesFromGithub();
+
     const res = await algoliaSdk.saveObjectsToIndex('lectures', lectures);
     return res;
   } catch (err) {

--- a/server/libs/algoliaSdk.ts
+++ b/server/libs/algoliaSdk.ts
@@ -40,6 +40,7 @@ const getObjectsFromIndex = async (indexName: string, search: string): Promise<a
  */
 const saveObjectsToIndex = async (indexName: string, objects: any): Promise<any> => {
   const data = objects.map((item: any) => ({ action: 'addObject', body: item }));
+
   const res = await fetch(`${ALGOLIA_WRITE_HOST}/1/indexes/${indexName}/batch`, {
     // TODO: next fetch 옵션 어떻게 할지 정하기
     // next: { revalidate: REVALIDATE_GITHUB_DATA },
@@ -54,9 +55,29 @@ const saveObjectsToIndex = async (indexName: string, objects: any): Promise<any>
   return res.json();
 };
 
+/**
+ * [POST] Algolia Search API - setSettingsToIndex
+ *
+ * @description 특정 index의 setting을 변경
+ * @links https://www.algolia.com/doc/rest-api/search/#set-settings
+ */
+const setSettingsToIndex = async (indexName: string, settings: any): Promise<any> => {
+  const res = await fetch(`${ALGOLIA_WRITE_HOST}/1/indexes/${indexName}/settings`, {
+    method: 'PUT',
+    headers: {
+      ...ALGOLIA_HEADERS,
+      'X-Algolia-API-Key': ALGOLIA_ADMIN_API_KEY,
+    },
+    body: JSON.stringify(settings),
+  });
+
+  return res.json();
+};
+
 const algoliaSdk = {
   getObjectsFromIndex,
   saveObjectsToIndex,
+  setSettingsToIndex,
 };
 
 export default algoliaSdk;

--- a/types/categories.type.ts
+++ b/types/categories.type.ts
@@ -1,4 +1,5 @@
-export type CategoryName = string; // TODO: 카테고리 획일화되면, 'frontend' | 'backend' | .. 로 변경하기
+// TODO: 카테고리 획일화되면, 'frontend' | 'backend' | .. 로 변경하기
+export type CategoryName = string;
 
 export type Category = {
   name: string;

--- a/types/creators.type.ts
+++ b/types/creators.type.ts
@@ -10,4 +10,5 @@ export type Creator = {
   name: string;
   category: CategoryName;
   lectures: GithubContentEntry[];
+  platforms?: string[];
 };

--- a/types/lectures.type.ts
+++ b/types/lectures.type.ts
@@ -9,4 +9,6 @@ export type Lecutre = {
   name: string;
   markdown: string;
   frontmatter: ContentsFrontmatter;
+  creator: string;
+  category: string;
 };

--- a/types/lectures.type.ts
+++ b/types/lectures.type.ts
@@ -1,3 +1,4 @@
+import { type CategoryName } from './categories.type';
 import { type ContentsFrontmatter } from './github.type';
 
 export type Lectures = {
@@ -10,5 +11,5 @@ export type Lecutre = {
   markdown: string;
   frontmatter: ContentsFrontmatter;
   creator: string;
-  category: string;
+  category: CategoryName;
 };


### PR DESCRIPTION
### Major Fix
- lectures API 수정
  - `creator`, `category` 정보 추가
 - creators API 수정
   - `plattforms` 정보 추가 

### Minor Fix
- 없음.

## Screenshots

### lectures API
<img width="1011" alt="스크린샷 2023-08-27 오후 5 33 16" src="https://github.com/meetup-fe-next/daview-ui/assets/42564107/5c0b80a6-a4c9-47bf-af06-411105447f02">

### creators API
<img width="985" alt="스크린샷 2023-08-27 오후 5 30 09" src="https://github.com/meetup-fe-next/daview-ui/assets/42564107/2e84c29c-2c3c-49c0-b780-8ca9de670f12">
